### PR TITLE
Make fingerprint a string

### DIFF
--- a/lib/rubocop/formatter/gitlab_formatter.rb
+++ b/lib/rubocop/formatter/gitlab_formatter.rb
@@ -40,7 +40,7 @@ module RuboCop
       def hash_for_offense(file, offense)
         {
           description: offense.message,
-          fingerprint: offense.hash,
+          fingerprint: offense.hash.to_s,
           severity: SEVERITY_MAPPING[offense.severity.code.to_sym],
           location: hash_for_location(file, offense.location)
         }


### PR DESCRIPTION
## Summary

The formatter output isn't being parsed without this change. It looks like GitLab might've started enforcing the CodeClimate report format more strictly.